### PR TITLE
Simplify Setup.hs to use less CPP

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -9,20 +9,12 @@ import System.Process
 import System.Exit
 import System.IO (hFlush, stdout)
 
-#if defined(MIN_VERSION_Cabal) && MIN_VERSION_Cabal(2,4,0)
-#define NORMALISE_ARGS (\_ _ -> id)
-#else
-#define NORMALISE_ARGS
-#endif
-
 main :: IO ()
 main = defaultMainWithHooks hk
  where
  hk = simpleUserHooks { buildHook = \pd lbi uh bf -> do
-                                        let ccProg = Program "gcc" undefined undefined undefined NORMALISE_ARGS
-                                            hcProg = Program "ghc" undefined undefined undefined NORMALISE_ARGS
-                                            mConf  = lookupProgram ccProg (withPrograms lbi)
-                                            hcConf = lookupProgram hcProg (withPrograms lbi)
+                                        let mConf  = lookupProgram gccProgram (withPrograms lbi)
+                                            hcConf = lookupProgram ghcProgram (withPrograms lbi)
                                             err = error "Could not determine C compiler"
                                             _cc  = locationPath . programLocation  . maybe err id $ mConf
                                             hc  = locationPath . programLocation  . maybe err id $ hcConf


### PR DESCRIPTION
`ccProg` and `hcProg` already exist in `Distribution.Simple.Program` under the names `gccProgram` and `ghcProgram`, respectively. This lets us remove the `NORMALISE_ARGS` CPP hack entirely.

I've tested this back to GHC 7.0.4.