### PR TITLE
allow building later stackges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.8.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}

--- a/cipher-aes128.cabal
+++ b/cipher-aes128.cabal
@@ -35,7 +35,7 @@ flag halvm
     default: False
 
 custom-setup
-  setup-depends: base >= 4.2 && <5, Cabal >= 1.10 && <2.5, process >=1.0
+  setup-depends: base >= 4.2 && <5, Cabal >= 1.10 && < 3.1, process >=1.0
 
 library
   default-language:    Haskell2010
@@ -67,6 +67,7 @@ benchmark bench
   type:         exitcode-stdio-1.0
   hs-source-dirs:       . Benchmark
   main-is:              bench.hs
+  other-modules: Crypto.Cipher.AES128, Crypto.Cipher.AES128.Internal
   build-depends:        base < 5, criterion, crypto-api, entropy, bytestring, tagged, cereal
   ghc-options:          -O2
   include-dirs:        cbits

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2019-10-31
+packages:
+- .

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2019-10-31
+packages:
+- .


### PR DESCRIPTION
There's a cap on Cabal version used but there's not problem with 3.0.0.0 so would like to raise the cap
have also tried this using ghc 8.8.1 on stackage nightly and had no issue